### PR TITLE
Ignore pnpm-lock.yaml when publishing to www.npmjs.com

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 .log
 .husky
 coverage
+pnpm-lock.yaml


### PR DESCRIPTION
This PR fixes the `pnpm-lock.yaml` to be ignored when publishing to npm.