### PR TITLE
Fix UMD moduleId

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default {
           },
         ],
       ],
-      moduleId: 'rison',
+      moduleId: 'rison2',
     }),
   ],
 };


### PR DESCRIPTION
This PR fixes the module ID of UMD to `rison2`.