### PR TITLE
Change the supported versions of Node.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 15.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@main
         with:
-          node-version: 15.x
+          node-version: 14.x
           registry-url: https://registry.npmjs.org
       - name: Cache ~/.pnpm-store
         uses: actions/cache@v2


### PR DESCRIPTION
This PR changes the supported versions of Node.js to 12, 14, and 16.