### PR TITLE
Bump version to v0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rison2",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Rison2 is a parser/stringifier of Rison",
   "main": "lib/index.js",
   "browser": "dist/rison2.js",


### PR DESCRIPTION
This PR bumps version to v0.2.3.

This release contains following PR:

- #16
- #17
- #18
- #20 

Diff: https://github.com/kou64yama/rison2/compare/v0.2.2...main

## Release notes

```markdown
## Changes

- Use Babel (#18)
```

## Release runbook

1. Merge this PR
2. Create a GitHub release