### PR TITLE
feat: Update Node.js support to LTS versions and clarify policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
           cache: pnpm
       - run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@main
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
           cache: pnpm
       - run: pnpm install

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Rison2 has a
 interface.
 
 ```js
-import { RISON } from 'rison2';
+import { RISON } from 'rison2'
 
-console.info(RISON.stringify({ message: 'こんにちは，世界' }));
+console.info(RISON.stringify({ message: 'こんにちは，世界' }))
 // '(message:こんにちは，世界)'
 
-console.info(RISON.parse('(message:こんにちは，世界)'));
+console.info(RISON.parse('(message:こんにちは，世界)'))
 // { message: 'こんにちは，世界' }
 ```
 
@@ -38,14 +38,18 @@ If you need percent encoding, import `rison2/lib/escaped` instead of
 `rison2`.
 
 ```js
-import { RISON } from 'rison2/lib/escaped';
+import { RISON } from 'rison2/lib/escaped'
 
-console.info(RISON.stringify({ kanji: '漢字' }));
+console.info(RISON.stringify({ kanji: '漢字' }))
 // '(kanji:%E6%BC%A2%E5%AD%97)'
 
-console.info(RISON.parse('(kanji:%E6%BC%A2%E5%AD%97)'));
+console.info(RISON.parse('(kanji:%E6%BC%A2%E5%AD%97)'))
 // { kanji: '漢字' }
 ```
+
+## Node.js Support Policy
+
+Rison2 supports Node.js versions that are currently in [Active LTS or Maintenance LTS](https://nodejs.org/en/about/previous-releases). This ensures compatibility with stable and actively supported Node.js environments.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "not dead"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",


### PR DESCRIPTION
This PR updates the Node.js support for the rison2 project. Changes include: - Updated package.json to specify Node.js >=20 to support Active LTS and Maintenance LTS versions. - Updated CI workflow files (.github/workflows/build.yml, .github/workflows/canary.yml, .github/workflows/release.yml) to use Node.js 20.x and 22.x in the build matrix. - Added a "Node.js Support Policy" section to README.md with a link to the official Node.js release schedule.