### PR TITLE
chore: resolve husky install deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "test": "jest",


### PR DESCRIPTION
## Description

Update `package.json` to resolve the `husky - install command is DEPRECATED` warning shown during `npm install`.

## Related Issue

Fixes #61

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🔧 Configuration/tooling change
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 📦 Dependency update

## Scope (for commit message)

- [ ] `lexer` - Tokenization and lexical analysis
- [ ] `parser` - Parsing logic and AST generation
- [ ] `stringifier` - Object serialization to RISON
- [ ] `deps` - Dependency updates
- [x] `config` - Configuration and build setup
- [ ] Other: [specify scope]

## Testing

- [x] Tested locally
- [ ] New tests added (if applicable)

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Breaking changes documented in commit message

## Additional Context

Husky v9 recommends using the `husky` command instead of `husky install` for the `prepare` script.