### PR TITLE
chore!: remove CommonJS and UMD builds, focus on ESM only

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig([
-  // Node.js build
+  // ESM build
   {
     entries: ['src/index', 'src/escaped'],
     outDir: 'lib',
@@ -12,57 +12,6 @@ export default defineBuildConfig([
       output: {
         format: 'esm',
         entryFileNames: '[name].js'
-      }
-    }
-  },
-  {
-    entries: ['src/index', 'src/escaped'],
-    outDir: 'lib',
-    declaration: false,
-    clean: false,
-    failOnWarn: false,
-    rollup: {
-      output: {
-        format: 'cjs',
-        entryFileNames: '[name].cjs'
-      }
-    }
-  },
-  // Browser build
-  {
-    entries: [{ input: 'src/index.ts', name: 'rison2' }],
-    outDir: 'dist',
-    declaration: false,
-    clean: true, // Clean dist directory
-    failOnWarn: false,
-    rollup: {
-      emitCJS: false,
-      esbuild: {
-        minify: false
-      },
-      output: {
-        format: 'umd',
-        entryFileNames: 'rison2.js',
-        name: 'rison2'
-      }
-    }
-  },
-  // Minified browser build
-  {
-    entries: [{ input: 'src/index.ts', name: 'rison2' }],
-    outDir: 'dist',
-    declaration: false,
-    clean: false, // Do not clean again
-    failOnWarn: false,
-    rollup: {
-      emitCJS: false,
-      esbuild: {
-        minify: true
-      },
-      output: {
-        format: 'umd',
-        entryFileNames: 'rison2.min.js',
-        name: 'rison2'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,23 +4,13 @@
   "description": "Rison2 is a parser/stringifier of Rison",
   "type": "module",
   "main": "lib/index.js",
-  "browser": "dist/rison2.js",
   "packageManager": "npm@11.12.1",
   "exports": {
-    ".": {
-      "import": "./lib/index.js",
-      "require": "./lib/index.cjs",
-      "default": "./lib/index.cjs"
-    },
-    "./lib/escaped": {
-      "import": "./lib/escaped.js",
-      "require": "./lib/escaped.cjs",
-      "default": "./lib/escaped.cjs"
-    }
+    ".": "./lib/index.js",
+    "./escaped": "./lib/escaped.js"
   },
   "files": [
-    "lib",
-    "dist"
+    "lib"
   ],
   "scripts": {
     "prepare": "husky",
@@ -42,11 +32,6 @@
     "url": "https://github.com/kou64yama/rison2/issues"
   },
   "homepage": "https://github.com/kou64yama/rison2#readme",
-  "browserslist": [
-    "last 2 versions",
-    "> 0.2%",
-    "not dead"
-  ],
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Description

Removes CommonJS and UMD builds to focus exclusively on ES Modules (ESM), simplifying the maintenance burden and build pipeline.

### Changes Made:
- Remove CommonJS (.cjs) build targets from build.config.ts
- Remove UMD browser build targets (dist directory)
- Simplify package.json exports to only include ESM builds
- Remove browser field and browserslist configuration
- Remove dist directory from package files
- Keep only lib directory with .js (ESM) and .d.ts files

## Related Issue

Related to #53

## Type of Change

- [x] 💥 Breaking change
- [x] 🔧 Configuration/tooling change

## Scope (for commit message)

Which component is primarily affected?

- [x] `config` - Configuration and build setup

## Testing

- [x] Tested locally
- [x] All 132 tests pass
- [x] Build completes successfully with ESM only

## Breaking Changes

- [x] This PR introduces breaking changes
- [x] Breaking changes documented in commit message

## Additional Context

This change aligns with modern web standards where both browsers and Node.js versions >= 20 natively support ES Modules. Maintaining multiple build targets adds unnecessary complexity without providing significant value.
