### PR TITLE
fix: add permissions blocks to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [20, 22, 24]

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds explicit `permissions` blocks to GitHub Actions workflows to resolve Code Scanning alerts.

## Changes
- **fossa.yml**: Add `contents: read` permission at workflow level
- **build.yml**: Add `contents: read` permission to test job

## Motivation
GitHub Actions workflows should contain explicit permissions to restrict the scope of the default GITHUB_TOKEN. This follows the principle of least privilege and improves security.

## References
- Code Scanning Alert: actions/missing-workflow-permissions
- GitHub Docs: Assigning permissions to jobs