### PR TITLE
build: drop support for Node.js 20

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ assignees: ''
 ## Environment
 
 - OS: [e.g., macOS, Windows, Linux]
-- Node.js Version: [e.g., 18.12.1, 20.0.0]
+- Node.js Version: [e.g., 22.0.0, 24.0.0]
 - Package Manager: [e.g., npm, yarn, pnpm]
 - Browser: [e.g., Chrome, Firefox, Safari] (if applicable)
 - Version: [e.g., 1.0.0] (version of the affected module)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Rison2! This guide will help you 
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (>= 20.0.0)
+- [Node.js](https://nodejs.org/) (>= 22.0.0)
 - [npm](https://www.npmjs.com/) (>= 10.0.0)
 
 We recommend using [mise](https://mise.jdx.dev/) or [nvm](https://github.com/nvm-sh/nvm) to manage your Node.js versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@swc/core": "^1.15.32",
-        "@tsconfig/node20": "^20.1.9",
+        "@tsconfig/node22": "^22.0.0",
         "@tsconfig/strictest": "^2.0.8",
         "@vitest/coverage-v8": "^4.1.5",
         "esbuild": "^0.28.0",
@@ -23,7 +23,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1951,10 +1951,10 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "homepage": "https://github.com/kou64yama/rison2#readme",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@swc/core": "^1.15.32",
-    "@tsconfig/node20": "^20.1.9",
+    "@tsconfig/node22": "^22.0.0",
     "@tsconfig/strictest": "^2.0.8",
     "@vitest/coverage-v8": "^4.1.5",
     "esbuild": "^0.28.0",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "composite": true
   },


### PR DESCRIPTION
## Description

Drop support for Node.js 20 as it has reached its end-of-life on 2026-03-24. The minimum supported version is now Node.js 22 (LTS).

## Type of Change

- [x] 💥 Breaking change
- [x] 🔧 Configuration/tooling change
- [x] 📦 Dependency update

## Scope (for commit message)

- [x] `config` - Configuration and build setup
- [x] `deps` - Dependency updates

## Testing

- [x] Tested locally (`npm run lint && npm run test && npm run build` passed)

## Breaking Changes

- [x] This PR introduces breaking changes
- [x] Breaking changes documented in commit message (Node.js 20 is no longer supported)

## Additional Context

Node.js 20 Maintenance period ended on 2026-03-24.
