### PR TITLE
build: resolve moduleResolution deprecation warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Description

The 'Node' (node10) module resolution strategy is deprecated and will be removed in TypeScript 7.0.
Since this project is an ESM-first library using modern build tools (unbuild/vitest), this PR updates the configuration to use 'Bundler' resolution.

## Related Issue

N/A

## Type of Change

- [x] 🔧 Configuration/tooling change

## Scope (for commit message)

- [x] `config` - Configuration and build setup

## Testing

- [x] Tested locally

## Breaking Changes

- [ ] This PR introduces breaking changes

## Additional Context

Verified with `tsc --noEmit`, `npm run test`, and `npm run build`.