### PR TITLE
docs: correct escaped import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ console.info(RISON.parse('(message:こんにちは，世界)'))
 // { message: 'こんにちは，世界' }
 ```
 
-If you need percent encoding, import `rison2/lib/escaped` instead of
+If you need percent encoding, import `rison2/escaped` instead of
 `rison2`.
 
 ```js
-import { RISON } from 'rison2/lib/escaped'
+import { RISON } from 'rison2/escaped'
 
 console.info(RISON.stringify({ kanji: '漢字' }))
 // '(kanji:%E6%BC%A2%E5%AD%97)'

--- a/examples/escaped.js
+++ b/examples/escaped.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { RISON } from 'rison2/lib/escaped'
+import { RISON } from 'rison2/escaped'
 
 console.info(RISON.stringify({ kanji: '漢字' }))
 // '(kanji:%E6%BC%A2%E5%AD%97)'

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "examples",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "rison2": "file:.."
+      }
+    },
+    "..": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.13",
+        "@swc/core": "^1.15.32",
+        "@tsconfig/node22": "^22.0.0",
+        "@tsconfig/strictest": "^2.0.8",
+        "@vitest/coverage-v8": "^4.1.5",
+        "esbuild": "^0.28.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3",
+        "typescript": "^5.9.3",
+        "unbuild": "^3.6.1",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/rison2": {
+      "resolved": "..",
+      "link": true
+    }
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "rison2": "link:.."
+    "rison2": "file:.."
   }
 }


### PR DESCRIPTION
## Description

Corrects the documented escaped module import path from `rison2/lib/escaped` to `rison2/escaped`.

Also updates the examples package metadata from `link:..` to npm-compatible `file:..` and adds the corresponding npm lockfile so the example can be installed and run with the current package manager.

## Related Issue

Closes #78 

<!--
IMPORTANT: Do not use auto-closing keywords unless:
1. This PR fully resolves the issue AND
2. All Acceptance Criteria in the issue have been verified/checked off

Auto-closing keywords to avoid: "Closes", "Close", "Closed", "Fixes", "Fix", "Fixed", "Resolves", "Resolve", "Resolved"
Use these keywords only when the issue should be automatically closed upon merge.
-->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🔧 Configuration/tooling change
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 📦 Dependency update

## Scope (for commit message)

Which component is primarily affected?

- [ ] `lexer` - Tokenization and lexical analysis
- [ ] `parser` - Parsing logic and AST generation
- [ ] `stringifier` - Object serialization to RISON
- [ ] `deps` - Dependency updates
- [ ] `config` - Configuration and build setup
- [x] Other: docs/examples

## Testing

- [x] Tested locally
- [ ] New tests added (if applicable)

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Breaking changes documented in commit message

## Additional Context

Tested with:

- `node examples/escaped.js`
- `npm run lint`
- `npm test -- --run`