### PR TITLE
docs: document core classes and escaping

### DIFF
--- a/src/escaped.ts
+++ b/src/escaped.ts
@@ -1,16 +1,23 @@
 import * as rison from './rison'
 
+// These URI characters and Rison punctuation need no percent-encoding.
 const ESCAPE_NO_REQUIRED = /^[-A-Za-z0-9~!*()_.',:@$/]*$/
 
 /**
- * this is like encodeURIComponent() but quotes fewer characters.
+ * Escapes Rison text for URLs while preserving Rison-safe punctuation.
+ *
+ * This uses `encodeURIComponent`, then restores selected punctuation and
+ * encodes spaces as `+`.
  *
  * See https://github.com/Nanonid/rison/blob/e64af6c096fd30950ec32cfd48526ca6ee21649d/js/rison.js#L107-L118
  *
  * This function is licensed under the MIT license found in the
  * https://github.com/Nanonid/rison/blob/e64af6c096fd30950ec32cfd48526ca6ee21649d/LICENSE.md.
  *
- * @param str
+ * @param str - The Rison text to escape.
+ * @returns The URL-escaped Rison text.
+ * @example
+ * _escape('hello world') // 'hello+world'
  */
 const _escape = (str: string): string => {
   if (ESCAPE_NO_REQUIRED.test(str)) return str
@@ -24,6 +31,14 @@ const _escape = (str: string): string => {
     .replace(/%20/g, '+')
 }
 
+/**
+ * Decodes URL-escaped Rison text, treating `+` as a space before decoding.
+ *
+ * @param str - The URL-escaped Rison text to decode.
+ * @returns The decoded Rison text.
+ * @example
+ * _unescape('hello+world') // 'hello world'
+ */
 const _unescape = (str: string): string =>
   decodeURIComponent(str.replace(/\+/g, '%20'))
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -29,6 +29,7 @@ const rules = {
       }
       switch (source[i]) {
         case '!':
+          // In a quoted string, `!` escapes the following character.
           i++
           continue
         case "'":
@@ -58,26 +59,49 @@ const RULES: Array<Rule<TokenKind>> = [
   rules.string(FALSE),
   rules.string(COLON),
   rules.string(COMMA),
+  // Bare identifiers cannot start with a digit or `-` and exclude Rison delimiters.
   rules.regexp(STRING, /^[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
+  // Numbers use a zero or non-zero-leading integer with optional fraction and exponent.
   rules.regexp(NUMBER, /^-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
 ]
 
+/**
+ * Tokenizes a Rison source string while tracking the current position.
+ */
 export class Lexer {
   #pos = 0
   #source: string
 
+  /**
+   * Creates a lexer for a Rison source string.
+   *
+   * @param source - The Rison source to tokenize.
+   */
   public constructor(source: string) {
     this.#source = source
   }
 
+  /**
+   * @returns The zero-based offset of the next unread character.
+   */
   public position(): number {
     return this.#pos
   }
 
+  /**
+   * @returns The number of characters in the source string.
+   */
   public length(): number {
     return this.#source.length
   }
 
+  /**
+   * Reads the next token and advances the current position.
+   *
+   * @returns The next token, or `null` when the source has been consumed.
+   * @throws {SyntaxError} If the source contains an invalid token or an
+   * unterminated quoted string.
+   */
   public nextToken(): Token<TokenKind> | null {
     if (this.#pos >= this.#source.length) return null
 
@@ -96,6 +120,12 @@ export class Lexer {
     )
   }
 
+  /**
+   * Creates an error for the most recently consumed token.
+   *
+   * @param token - The unexpected token.
+   * @returns A syntax error containing the token and its source position.
+   */
   public syntaxError(token: Token): SyntaxError {
     const pos = this.#pos - token.value.length
     return new SyntaxError(

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -59,7 +59,8 @@ const RULES: Array<Rule<TokenKind>> = [
   rules.string(FALSE),
   rules.string(COLON),
   rules.string(COMMA),
-  // Bare identifiers cannot start with a digit or `-` and exclude Rison delimiters.
+  // A bare identifier cannot start with a digit or `-`; all characters exclude
+  // the ASCII space, quote, and Rison reserved punctuation.
   rules.regexp(STRING, /^[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
   // Numbers use a zero or non-zero-leading integer with optional fraction and exponent.
   rules.regexp(NUMBER, /^-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -83,14 +83,14 @@ export class Lexer {
   }
 
   /**
-   * @returns The zero-based offset of the next unread character.
+   * @returns The zero-based offset of the next unread UTF-16 code unit.
    */
   public position(): number {
     return this.#pos
   }
 
   /**
-   * @returns The number of characters in the source string.
+   * @returns The source string's length in UTF-16 code units.
    */
   public length(): number {
     return this.#source.length

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,13 +14,28 @@ import {
   type TokenKind
 } from './token'
 
+/**
+ * Parses tokens from a lexer into JavaScript values.
+ */
 export class Parser {
   readonly #lexer: Lexer
 
+  /**
+   * Creates a parser backed by a lexer.
+   *
+   * @param lexer - The lexer that provides Rison tokens.
+   */
   public constructor(lexer: Lexer) {
     this.#lexer = lexer
   }
 
+  /**
+   * Parses one complete Rison value.
+   *
+   * @returns The JavaScript value represented by the Rison input.
+   * @throws {SyntaxError} If the input is empty, malformed, or contains tokens
+   * after the parsed value.
+   */
   public readAsAny(): unknown {
     const val = this.asAny(this.nextToken())
     if (this.#lexer.position() < this.#lexer.length()) {
@@ -51,6 +66,7 @@ export class Parser {
   }
 
   private asString(token: Token): string {
+    // Remove Rison's escape marker: `!!` represents `!`, and `!'` represents `'`.
     return token.value[0] === "'"
       ? token.value.replace(/!./g, (c) => c[1] as string).slice(1, -1)
       : token.value

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -9,9 +9,22 @@ import {
   TRUE
 } from './token'
 
+// A bare identifier cannot start with a digit or `-`; all characters exclude
+// the ASCII space, quote, and Rison reserved punctuation.
 const ID_REGEXP = /^[^0-9- '!:(),*@$][^ '!:(),*@$]*$/
 
+/**
+ * Serializes JavaScript values as Rison.
+ */
 export class Stringifier {
+  /**
+   * Serializes a supported JavaScript value as a complete Rison value.
+   *
+   * @param value - The value to serialize.
+   * @returns The Rison representation, or `undefined` for `undefined` and
+   * unsupported value types.
+   * @throws {TypeError} If a BigInt is encountered.
+   */
   public value(value: unknown): string | undefined {
     if (value === undefined) return undefined
     if (value === null) return NULL
@@ -33,6 +46,13 @@ export class Stringifier {
     }
   }
 
+  /**
+   * Serializes an object's entries without the surrounding Rison delimiters.
+   * Properties whose values serialize to `undefined` are omitted.
+   *
+   * @param value - The object whose enumerable own properties to serialize.
+   * @returns The comma-separated Rison key-value pairs.
+   */
   public object(value: object): string {
     return Object.entries(value).reduce<string>((prev, [key, value]) => {
       const str = this.value(value)
@@ -43,6 +63,13 @@ export class Stringifier {
     }, '')
   }
 
+  /**
+   * Serializes an array's elements without the surrounding Rison delimiters.
+   * Elements that serialize to `undefined` are represented as Rison null.
+   *
+   * @param value - The array to serialize.
+   * @returns The comma-separated Rison values.
+   */
   public array(value: unknown[]): string {
     return value.reduce<string>((prev, value) => {
       const str = this.value(value) ?? NULL
@@ -50,15 +77,29 @@ export class Stringifier {
     }, '')
   }
 
+  /**
+   * @param value - The boolean to serialize.
+   * @returns The Rison boolean literal.
+   */
   public boolean(value: boolean): string {
     return value ? TRUE : FALSE
   }
 
+  /**
+   * @param value - The number to serialize.
+   * @returns The Rison number, or Rison null when the number is not finite.
+   */
   public number(value: number): string {
+    // Rison exponents omit the optional `+` accepted by JavaScript numbers.
     return Number.isFinite(value) ? value.toString().replace('+', '') : NULL
   }
 
+  /**
+   * @param value - The string to serialize.
+   * @returns A bare identifier when allowed, otherwise a quoted Rison string.
+   */
   public string(value: string): string {
+    // Rison escapes both its escape marker and quote by prefixing them with `!`.
     return ID_REGEXP.test(value)
       ? value
       : `'${value.replace(/[!']/g, (c) => `!${c}`)}'`


### PR DESCRIPTION
Add JSDoc to the Lexer, Parser, and Stringifier classes and their public APIs. Document return values, error behavior, and serialization rules for unsupported and non-finite values.

Explain Rison identifier and number patterns, quoted string escaping, and URL escape and unescape behavior with concise examples.

Refs: #74