### PR TITLE
refactor: track lexer token positions explicitly

### DIFF
--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -1,0 +1,30 @@
+import { Lexer } from './lexer'
+
+describe('Lexer.syntaxError', () => {
+  it.each([
+    ["('hello'", "Unexpected token ' in Rison at position 1"],
+    ['hello,world', 'Unexpected token , in Rison at position 5'],
+    ['(hello', 'Unexpected token h in Rison at position 1']
+  ])('reports the position of a token after the start of %j', (source, message) => {
+    const lexer = new Lexer(source)
+    lexer.nextToken()
+    const token = lexer.nextToken()
+
+    if (token === null) throw new Error('Expected a token')
+    expect(lexer.syntaxError(token)).toHaveProperty('message', message)
+  })
+
+  it('does not derive the position from the token value', () => {
+    const lexer = new Lexer('(hello')
+    lexer.nextToken()
+    const token = lexer.nextToken()
+
+    if (token === null) throw new Error('Expected a token')
+    token.value = 'a different length'
+
+    expect(lexer.syntaxError(token)).toHaveProperty(
+      'message',
+      'Unexpected token h in Rison at position 1'
+    )
+  })
+})

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -33,19 +33,25 @@ const rules = {
           i++
           continue
         case "'":
-          return { kind: STRING, value: source.slice(pos, i + 1) }
+          return {
+            kind: STRING,
+            value: source.slice(pos, i + 1),
+            position: pos
+          }
       }
     }
   },
   string:
     <T extends TokenKind>(kind: T): Rule<T> =>
     (source, pos) =>
-      source.startsWith(kind, pos) ? { kind, value: kind } : null,
+      source.startsWith(kind, pos)
+        ? { kind, value: kind, position: pos }
+        : null,
   regexp:
     <T extends TokenKind>(kind: T, reg: RegExp): Rule<T> =>
     (source, pos) => {
       const match = reg.exec(source.slice(pos))
-      return match != null ? { kind, value: match[0] } : null
+      return match != null ? { kind, value: match[0], position: pos } : null
     }
 }
 
@@ -128,9 +134,10 @@ export class Lexer {
    * @returns A syntax error containing the token and its source position.
    */
   public syntaxError(token: Token): SyntaxError {
-    const pos = this.#pos - token.value.length
     return new SyntaxError(
-      `Unexpected token ${this.#source[pos]} in Rison at position ${pos}`
+      `Unexpected token ${this.#source[token.position]} in Rison at position ${
+        token.position
+      }`
     )
   }
 }

--- a/src/rison.test.ts
+++ b/src/rison.test.ts
@@ -82,6 +82,20 @@ describe('RISON.parse', () => {
   it.each(syntaxErrors)('throws SyntaxError when it given %j', (input) => {
     expect(() => RISON.parse(input)).toThrow(SyntaxError)
   })
+
+  it.each([
+    ['hello,world', 'Unexpected token , in Rison at position 5'],
+    ['!tinvalid', 'Unexpected token i in Rison at position 2'],
+    ["'hello')", 'Unexpected token ) in Rison at position 7']
+  ])('reports the exact invalid token position for %j', (input, message) => {
+    try {
+      RISON.parse(input)
+      throw new Error('Expected RISON.parse to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SyntaxError)
+      expect(error).toHaveProperty('message', message)
+    }
+  })
 })
 
 describe('RISON.stringify', () => {

--- a/src/token.ts
+++ b/src/token.ts
@@ -24,4 +24,5 @@ export type TokenKind =
 export interface Token<T extends TokenKind = TokenKind> {
   kind: T
   value: string
+  position: number
 }


### PR DESCRIPTION
Store each token's UTF-16 start offset when the lexer matches it.

Use the stored offset when constructing parser syntax errors instead of deriving the position from the token value length. Add focused lexer and public parser coverage for fixed, regular-expression, and quoted-string token paths.