### PR TITLE
perf: optimize lexer and stringifier

### DIFF
--- a/bench/performance.bench.ts
+++ b/bench/performance.bench.ts
@@ -132,8 +132,14 @@ class BaselineStringifier extends Stringifier {
   }
 }
 
-const collection = Array.from({ length: 5_000 }, (_, index) =>
+const arrayCollection = Array.from({ length: 5_000 }, (_, index) =>
   index % 3 === 0 ? undefined : index
+)
+const objectCollection = Object.fromEntries(
+  Array.from({ length: 5_000 }, (_, index) => [
+    `key${index}`,
+    index % 3 === 0 ? undefined : index
+  ])
 )
 const benchOptions = { time: 1_500, warmupTime: 1_000 }
 
@@ -143,8 +149,11 @@ function readMiddle(value: string): number {
 
 const baselineStringifier = new BaselineStringifier()
 const stringifier = new Stringifier()
-expect(stringifier.array(collection)).toBe(
-  baselineStringifier.array(collection)
+expect(stringifier.array(arrayCollection)).toBe(
+  baselineStringifier.array(arrayCollection)
+)
+expect(stringifier.object(objectCollection)).toBe(
+  baselineStringifier.object(objectCollection)
 )
 
 for (const size of [100, 1_000, 10_000]) {
@@ -170,12 +179,30 @@ for (const size of [100, 1_000, 10_000]) {
   })
 }
 
-describe('Stringifier', () => {
+describe('Stringifier array', () => {
   bench(
     'reduce baseline',
-    () => readMiddle(baselineStringifier.array(collection)),
+    () => readMiddle(baselineStringifier.array(arrayCollection)),
     benchOptions
   )
 
-  bench('join', () => readMiddle(stringifier.array(collection)), benchOptions)
+  bench(
+    'join',
+    () => readMiddle(stringifier.array(arrayCollection)),
+    benchOptions
+  )
+})
+
+describe('Stringifier object', () => {
+  bench(
+    'reduce baseline',
+    () => readMiddle(baselineStringifier.object(objectCollection)),
+    benchOptions
+  )
+
+  bench(
+    'join',
+    () => readMiddle(stringifier.object(objectCollection)),
+    benchOptions
+  )
 })

--- a/bench/performance.bench.ts
+++ b/bench/performance.bench.ts
@@ -1,0 +1,181 @@
+import { bench, describe, expect } from 'vitest'
+import { Lexer } from '../src/lexer'
+import { Stringifier } from '../src/stringifier'
+import {
+  ARRAY_START,
+  COLON,
+  COMMA,
+  FALSE,
+  NULL,
+  NUMBER,
+  OBJECT_ARRAY_END,
+  OBJECT_START,
+  STRING,
+  TRUE,
+  type Token,
+  type TokenKind
+} from '../src/token'
+
+type Rule<T extends TokenKind> = (
+  source: string,
+  pos: number
+) => Token<T> | null
+
+const baselineRules = {
+  quote: (): Rule<typeof STRING> => (source, pos) => {
+    if (!source.startsWith("'", pos)) return null
+
+    let i = pos
+    while (true) {
+      if (source.length <= ++i) {
+        throw new SyntaxError('Unexpected end of Rison input')
+      }
+      switch (source[i]) {
+        case '!':
+          i++
+          continue
+        case "'":
+          return { kind: STRING, value: source.slice(pos, i + 1) }
+      }
+    }
+  },
+  string:
+    <T extends TokenKind>(kind: T): Rule<T> =>
+    (source, pos) =>
+      source.startsWith(kind, pos) ? { kind, value: kind } : null,
+  regexp:
+    <T extends TokenKind>(kind: T, regexp: RegExp): Rule<T> =>
+    (source, pos) => {
+      const match = regexp.exec(source.slice(pos))
+      return match === null ? null : { kind, value: match[0] }
+    }
+}
+
+// Issue #77 baseline: Lexer rules before sticky regular expressions.
+const BASELINE_RULES: Array<Rule<TokenKind>> = [
+  baselineRules.quote(),
+  baselineRules.string(OBJECT_START),
+  baselineRules.string(ARRAY_START),
+  baselineRules.string(OBJECT_ARRAY_END),
+  baselineRules.string(NULL),
+  baselineRules.string(TRUE),
+  baselineRules.string(FALSE),
+  baselineRules.string(COLON),
+  baselineRules.string(COMMA),
+  baselineRules.regexp(STRING, /^[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
+  baselineRules.regexp(NUMBER, /^-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
+]
+
+class BaselineLexer {
+  #pos = 0
+
+  public constructor(private readonly source: string) {}
+
+  public nextToken(): Token<TokenKind> | null {
+    if (this.#pos >= this.source.length) return null
+
+    for (const rule of BASELINE_RULES) {
+      const token = rule(this.source, this.#pos)
+      if (token !== null) {
+        this.#pos += token.value.length
+        return token
+      }
+    }
+
+    throw new SyntaxError(
+      `Unexpected token ${this.source[this.#pos]} in Rison at position ${
+        this.#pos
+      }`
+    )
+  }
+}
+
+function collect(lexer: Pick<Lexer, 'nextToken'>): Token<TokenKind>[] {
+  const tokens: Token<TokenKind>[] = []
+  let token = lexer.nextToken()
+  while (token !== null) {
+    tokens.push(token)
+    token = lexer.nextToken()
+  }
+  return tokens
+}
+
+function consume(lexer: Pick<Lexer, 'nextToken'>): number {
+  let checksum = 0
+  let token = lexer.nextToken()
+  while (token !== null) {
+    checksum = (checksum * 31 + token.kind.length + token.value.length) | 0
+    token = lexer.nextToken()
+  }
+  return checksum
+}
+
+// Issue #77 baseline: collection serialization before Array.join.
+class BaselineStringifier extends Stringifier {
+  public override object(value: object): string {
+    return Object.entries(value).reduce<string>((previous, [key, value]) => {
+      const serialized = this.value(value)
+      if (serialized === undefined) return previous
+
+      const pair = `${this.string(key)}${COLON}${serialized}`
+      return previous.length > 0 ? `${previous}${COMMA}${pair}` : pair
+    }, '')
+  }
+
+  public override array(value: unknown[]): string {
+    return value.reduce<string>((previous, value) => {
+      const serialized = this.value(value) ?? NULL
+      return previous.length > 0
+        ? `${previous}${COMMA}${serialized}`
+        : serialized
+    }, '')
+  }
+}
+
+const collection = Array.from({ length: 5_000 }, (_, index) =>
+  index % 3 === 0 ? undefined : index
+)
+const benchOptions = { time: 1_500, warmupTime: 1_000 }
+
+function readMiddle(value: string): number {
+  return value.charCodeAt(Math.floor(value.length / 2))
+}
+
+const baselineStringifier = new BaselineStringifier()
+const stringifier = new Stringifier()
+expect(stringifier.array(collection)).toBe(
+  baselineStringifier.array(collection)
+)
+
+for (const size of [100, 1_000, 10_000]) {
+  const entries = Array.from(
+    { length: size },
+    (_, index) => [`key${index}`, index] as const
+  )
+  const rison = `(${entries
+    .map(([key, value]) => `${key}:${value}`)
+    .join(',')})`
+
+  const baselineTokens = collect(new BaselineLexer(rison))
+  expect(collect(new Lexer(rison))).toStrictEqual(baselineTokens)
+
+  describe(`Lexer (${size.toLocaleString()} entries)`, () => {
+    bench(
+      'source.slice baseline',
+      () => consume(new BaselineLexer(rison)),
+      benchOptions
+    )
+
+    bench('sticky regexp', () => consume(new Lexer(rison)), benchOptions)
+  })
+}
+
+describe('Stringifier', () => {
+  bench(
+    'reduce baseline',
+    () => readMiddle(baselineStringifier.array(collection)),
+    benchOptions
+  )
+
+  bench('join', () => readMiddle(stringifier.array(collection)), benchOptions)
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "prepare": "husky",
+    "bench": "vitest bench --run",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "test": "vitest",

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -1,0 +1,47 @@
+import { Lexer } from './lexer'
+import {
+  COLON,
+  FALSE,
+  NUMBER,
+  OBJECT_ARRAY_END,
+  OBJECT_START,
+  STRING,
+  TRUE
+} from './token'
+
+describe('Lexer', () => {
+  it('recognizes identifiers and numbers away from the start', () => {
+    const lexer = new Lexer('(answer:42)')
+
+    expect([
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken()
+    ]).toStrictEqual([
+      { kind: OBJECT_START, value: '(' },
+      { kind: STRING, value: 'answer' },
+      { kind: COLON, value: ':' },
+      { kind: NUMBER, value: '42' },
+      { kind: OBJECT_ARRAY_END, value: ')' }
+    ])
+  })
+
+  it('recognizes consecutive tokens', () => {
+    const lexer = new Lexer('!t!f')
+
+    expect(lexer.nextToken()).toStrictEqual({ kind: TRUE, value: '!t' })
+    expect(lexer.nextToken()).toStrictEqual({ kind: FALSE, value: '!f' })
+    expect(lexer.nextToken()).toBeNull()
+  })
+
+  it('reports the position of an invalid character', () => {
+    const lexer = new Lexer('valid*invalid')
+
+    expect(lexer.nextToken()).toStrictEqual({ kind: STRING, value: 'valid' })
+    expect(() => lexer.nextToken()).toThrow(
+      'Unexpected token * in Rison at position 5'
+    )
+  })
+})

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -43,7 +43,8 @@ const rules = {
   regexp:
     <T extends TokenKind>(kind: T, reg: RegExp): Rule<T> =>
     (source, pos) => {
-      const match = reg.exec(source.slice(pos))
+      reg.lastIndex = pos
+      const match = reg.exec(source)
       return match != null ? { kind, value: match[0] } : null
     }
 }
@@ -58,8 +59,8 @@ const RULES: Array<Rule<TokenKind>> = [
   rules.string(FALSE),
   rules.string(COLON),
   rules.string(COMMA),
-  rules.regexp(STRING, /^[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
-  rules.regexp(NUMBER, /^-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
+  rules.regexp(STRING, /[^0-9- '!:(),*@$][^ '!:(),*@$]*/y),
+  rules.regexp(NUMBER, /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/y)
 ]
 
 export class Lexer {

--- a/src/rison.test.ts
+++ b/src/rison.test.ts
@@ -106,12 +106,22 @@ describe('RISON.stringify', () => {
     expect(() => RISON.stringify(bigint)).toThrow(TypeError)
   })
 
-  it('ignores undefined in the object', () => {
-    expect(RISON.stringify({ foo: undefined })).toBe('()')
+  it('ignores unsupported values in objects while preserving order', () => {
+    expect(
+      RISON.stringify({
+        first: 1,
+        undefined,
+        function: () => null,
+        symbol: Symbol('symbol'),
+        last: 2
+      })
+    ).toBe('(first:1,last:2)')
   })
 
-  it('ignores undefined in the array', () => {
-    expect(RISON.stringify([undefined])).toBe('!(!n)')
+  it('replaces unsupported array values with null while preserving order', () => {
+    expect(
+      RISON.stringify([1, undefined, () => null, Symbol('symbol'), 2])
+    ).toBe('!(1,!n,!n,!n,2)')
   })
 })
 

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -34,20 +34,16 @@ export class Stringifier {
   }
 
   public object(value: object): string {
-    return Object.entries(value).reduce<string>((prev, [key, value]) => {
-      const str = this.value(value)
-      if (str === undefined) return prev
-
-      const pair = `${this.string(key)}${COLON}${str}`
-      return prev.length > 0 ? `${prev}${COMMA}${pair}` : pair
-    }, '')
+    return Object.entries(value)
+      .flatMap(([key, value]) => {
+        const str = this.value(value)
+        return str === undefined ? [] : `${this.string(key)}${COLON}${str}`
+      })
+      .join(COMMA)
   }
 
   public array(value: unknown[]): string {
-    return value.reduce<string>((prev, value) => {
-      const str = this.value(value) ?? NULL
-      return prev.length > 0 ? `${prev}${COMMA}${str}` : str
-    }, '')
+    return value.map((value) => this.value(value) ?? NULL).join(COMMA)
   }
 
   public boolean(value: boolean): string {

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -34,12 +34,14 @@ export class Stringifier {
   }
 
   public object(value: object): string {
-    return Object.entries(value)
-      .flatMap(([key, value]) => {
-        const str = this.value(value)
-        return str === undefined ? [] : `${this.string(key)}${COLON}${str}`
-      })
-      .join(COMMA)
+    const pairs: string[] = []
+    for (const [key, entry] of Object.entries(value)) {
+      const str = this.value(entry)
+      if (str !== undefined) {
+        pairs.push(`${this.string(key)}${COLON}${str}`)
+      }
+    }
+    return pairs.join(COMMA)
   }
 
   public array(value: unknown[]): string {


### PR DESCRIPTION
Match lexer regular expressions against the original source with sticky matching to avoid slicing the remaining input.

Build serialized arrays and objects with joined element buffers instead of repeatedly concatenating growing strings.

Add regression tests and reproducible Vitest benchmarks for the optimized paths.

Closes #77