### PR TITLE
perf: optimize lexer and stringifier

### DIFF
--- a/bench/performance.bench.ts
+++ b/bench/performance.bench.ts
@@ -1,6 +1,7 @@
 import { bench, describe } from 'vitest'
 
 import { Lexer } from '../src/lexer'
+import { Stringifier } from '../src/stringifier'
 
 const BENCHMARK_OPTIONS = {
   time: 100,
@@ -98,4 +99,32 @@ describe('Lexer token matching', () => {
       BENCHMARK_OPTIONS
     )
   }
+})
+
+const stringifier = new Stringifier()
+const collectionSize = 5_000
+const largeArray = Array.from({ length: collectionSize }, (_, index) => ({
+  id: `item${index}`,
+  count: index,
+  active: index % 2 === 0
+}))
+const largeObject = Object.fromEntries(
+  Array.from({ length: collectionSize }, (_, index) => [
+    `field${index}`,
+    index % 10 === 0 ? undefined : `value${index}`
+  ])
+)
+
+describe('Stringifier collection joining', () => {
+  bench(
+    `array: ${collectionSize} elements`,
+    () => stringifier.array(largeArray),
+    BENCHMARK_OPTIONS
+  )
+
+  bench(
+    `object: ${collectionSize} properties`,
+    () => stringifier.object(largeObject),
+    BENCHMARK_OPTIONS
+  )
 })

--- a/docs/lexer-performance.md
+++ b/docs/lexer-performance.md
@@ -2,21 +2,24 @@
 
 ## Purpose and Scope
 
-This investigation profiles the existing `Lexer` token matching behavior for
-representative token streams. It measures the lexer in isolation: each
-benchmark constructs a `Lexer` and consumes tokens until end of input. Input
-generation and token counting happen outside the measured callback.
+This document records the investigation and optimization of `Lexer` token
+matching for representative token streams. The benchmark measures the lexer in
+isolation: each iteration constructs a `Lexer` and consumes tokens until end of
+input. Input generation and token counting happen outside the measured
+callback.
 
-The investigation does not modify the production lexer, compare alternative
-lexer implementations, or measure parsing and value construction.
+The optimized lexer uses sticky regular expressions to match against the
+original source at the current position. This avoids allocating
+`source.slice(pos)` for every attempted regexp rule. The benchmark does not
+measure parsing or value construction.
 
 ## Reproduction
 
-Install dependencies and run the focused benchmarks:
+Install dependencies and run the lexer benchmarks:
 
 ```bash
 npm install
-npm run bench
+npm run bench -- --testNamePattern='Lexer token matching'
 ```
 
 Run the benchmark several times when comparing results. CPU frequency,
@@ -72,45 +75,19 @@ booleans, punctuation, and separators.
 ## Results
 
 The following values are the median throughput from three complete benchmark
-runs. The range shows the lowest and highest result from those runs.
+runs of the current implementation. The range shows the lowest and highest
+result from those runs.
 
 | Shape          | Small ops/s, median (range) | Large ops/s, median (range) |
 | -------------- | --------------------------: | --------------------------: |
-| Fixed tokens   |   120,922 (112,857-128,356) |      11,498 (11,141-12,526) |
-| Identifiers    |      78,926 (73,249-79,085) |         9,136 (7,796-9,168) |
-| Numbers        |      62,752 (60,482-73,035) |         6,755 (6,059-6,946) |
-| Quoted strings |   129,775 (121,874-133,632) |      12,767 (11,954-13,927) |
-| Mixed objects  |      63,138 (58,908-67,658) |         6,309 (6,193-6,376) |
+| Fixed tokens   |   175,022 (168,786-183,915) |      19,734 (17,279-20,281) |
+| Identifiers    |   132,720 (120,831-133,532) |      10,969 (10,908-13,722) |
+| Numbers        |    101,678 (97,297-109,696) |       10,258 (9,755-10,912) |
+| Quoted strings |   205,415 (203,973-208,407) |      20,639 (19,683-21,231) |
+| Mixed objects  |    100,279 (96,229-101,070) |         9,453 (9,212-9,625) |
 
 These absolute values are environment-dependent and are not regression
-thresholds. The large cases show approximately linear scaling with token
-count. Numbers and mixed objects are slower per operation than fixed or quoted
-tokens because they exercise more late-position rules and token kinds.
-
-## CPU Profile Findings
-
-Two profiles were captured with a 100 microsecond sampling interval. Grouping
-self-time samples by source URL and function name produced these ranges:
-
-| Sample group                                 | Share of profiled time |
-| -------------------------------------------- | ---------------------: |
-| `src/lexer.ts` rule matching and `nextToken` |            58.8%-60.3% |
-| Benchmark callback and loop                  |            16.4%-18.0% |
-| Tinybench harness                            |            11.6%-12.0% |
-| Native regular expression execution          |              4.0%-4.3% |
-| Garbage collection                           |              1.0%-1.1% |
-
-The profile locates most measured self time in the lexer's rule callbacks.
-For every token, rules are tried sequentially from `RULES` until one matches.
-Native regular expression execution is visible but is not the dominant sampled
-cost. Garbage collection is also not dominant in these runs.
-
-The profile cannot reliably separate every inlined operation inside an
-anonymous rule callback. In particular, it does not establish how much of a
-regexp rule's cost comes from `source.slice(pos)` versus `RegExp.exec`.
-Therefore, the evidence supports investigating rule dispatch and matching at
-the current position, but not attributing a precise percentage to either
-operation.
+thresholds.
 
 ## Optimization Assessment
 
@@ -128,12 +105,15 @@ without reuse, so it is not recommended.
 
 ### Sticky Regular Expressions
 
-Sticky regular expressions can match at `lastIndex = pos`, avoiding the
-current `source.slice(pos)` before regexp matching. This directly targets work
-inside the sampled rule callbacks, but this investigation does not measure an
-alternative implementation. Issue #77 owns the production sticky-regexp
-optimization and should validate it against these focused cases plus the
-correctness test suite.
+Regexp rules now clone their expression with the sticky (`y`) flag when the
+rule is created. Before each match, the rule sets `lastIndex = pos` and executes
+the expression against the original source. The identifier and number patterns
+no longer use `^`, because sticky matching already requires the match to begin
+at `lastIndex`.
+
+Resetting `lastIndex` for every attempt is required because sticky regular
+expressions are stateful. Regression tests cover regexp tokens at non-zero
+positions and matching after preceding rules fail.
 
 ### Direct Dispatch
 
@@ -146,11 +126,11 @@ implementation demonstrates a meaningful improvement over sticky matching.
 
 ## Recommendation
 
-Do not add pre-compilation or memoization changes. Use the benchmark as a
-repeatable baseline for Issue #77, where sticky regular expressions should be
-implemented and compared with the current lexer. Consider direct dispatch
-only if sticky matching leaves a demonstrated bottleneck large enough to
-justify the added complexity.
+Keep the sticky-regexp implementation and use this benchmark for future lexer
+changes. Do not add memoization, because normal tokenization does not revisit
+source positions. Consider direct dispatch only if a separate benchmark shows
+an improvement large enough to justify the additional lexical classification
+logic.
 
 ## Limitations
 
@@ -160,6 +140,4 @@ justify the added complexity.
   for parsed values.
 - Each case uses a short measurement window, so repeated runs are more useful
   than a single absolute result.
-- Sampling profiles and JIT inlining limit attribution within anonymous rule
-  callbacks.
-- No alternative production implementation was measured in this issue.
+- JIT compilation and inlining can affect short benchmark runs.

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -1,4 +1,25 @@
 import { Lexer } from './lexer'
+import { COMMA, NUMBER, OBJECT_ARRAY_END, OBJECT_START, STRING } from './token'
+
+describe('Lexer.nextToken', () => {
+  it('matches regular expressions at the current position after failures', () => {
+    const lexer = new Lexer('(42,field)')
+
+    expect([
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken()
+    ]).toStrictEqual([
+      { kind: OBJECT_START, value: '(', position: 0 },
+      { kind: NUMBER, value: '42', position: 1 },
+      { kind: COMMA, value: ',', position: 3 },
+      { kind: STRING, value: 'field', position: 4 },
+      { kind: OBJECT_ARRAY_END, value: ')', position: 9 }
+    ])
+  })
+})
 
 describe('Lexer.syntaxError', () => {
   it.each([

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -47,12 +47,18 @@ const rules = {
       source.startsWith(kind, pos)
         ? { kind, value: kind, position: pos }
         : null,
-  regexp:
-    <T extends TokenKind>(kind: T, reg: RegExp): Rule<T> =>
-    (source, pos) => {
-      const match = reg.exec(source.slice(pos))
+  regexp: <T extends TokenKind>(kind: T, reg: RegExp): Rule<T> => {
+    const sticky = new RegExp(
+      reg.source,
+      reg.sticky ? reg.flags : `${reg.flags}y`
+    )
+
+    return (source, pos) => {
+      sticky.lastIndex = pos
+      const match = sticky.exec(source)
       return match != null ? { kind, value: match[0], position: pos } : null
     }
+  }
 }
 
 const RULES: Array<Rule<TokenKind>> = [
@@ -67,9 +73,9 @@ const RULES: Array<Rule<TokenKind>> = [
   rules.string(COMMA),
   // A bare identifier cannot start with a digit or `-`; all characters exclude
   // the ASCII space, quote, and Rison reserved punctuation.
-  rules.regexp(STRING, /^[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
+  rules.regexp(STRING, /[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
   // Numbers use a zero or non-zero-leading integer with optional fraction and exponent.
-  rules.regexp(NUMBER, /^-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
+  rules.regexp(NUMBER, /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
 ]
 
 /**

--- a/src/rison.test.ts
+++ b/src/rison.test.ts
@@ -124,8 +124,12 @@ describe('RISON.stringify', () => {
     expect(RISON.stringify({ foo: undefined })).toBe('()')
   })
 
-  it('ignores undefined in the array', () => {
+  it('represents undefined in the array as null', () => {
     expect(RISON.stringify([undefined])).toBe('!(!n)')
+  })
+
+  it('ignores holes in sparse arrays', () => {
+    expect(RISON.stringify(Array(1))).toBe('!()')
   })
 })
 

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -54,13 +54,13 @@ export class Stringifier {
    * @returns The comma-separated Rison key-value pairs.
    */
   public object(value: object): string {
-    return Object.entries(value).reduce<string>((prev, [key, value]) => {
-      const str = this.value(value)
-      if (str === undefined) return prev
-
-      const pair = `${this.string(key)}${COLON}${str}`
-      return prev.length > 0 ? `${prev}${COMMA}${pair}` : pair
-    }, '')
+    const pairs: string[] = []
+    for (const [key, entryValue] of Object.entries(value)) {
+      const str = this.value(entryValue)
+      if (str === undefined) continue
+      pairs.push(`${this.string(key)}${COLON}${str}`)
+    }
+    return pairs.join(COMMA)
   }
 
   /**
@@ -71,10 +71,12 @@ export class Stringifier {
    * @returns The comma-separated Rison values.
    */
   public array(value: unknown[]): string {
-    return value.reduce<string>((prev, value) => {
-      const str = this.value(value) ?? NULL
-      return prev.length > 0 ? `${prev}${COMMA}${str}` : str
-    }, '')
+    const values: string[] = []
+    for (let i = 0; i < value.length; i++) {
+      if (!(i in value)) continue
+      values.push(this.value(value[i]) ?? NULL)
+    }
+    return values.join(COMMA)
   }
 
   /**


### PR DESCRIPTION
Match lexer regular expressions against the original source with sticky
matching to avoid allocating a sliced string for every attempted rule.

Collect serialized array elements and object entries before joining them,
while preserving undefined values and sparse-array behavior. Add regression
tests and focused collection benchmarks.

Closes: #77