### PR TITLE
perf: remove lexer rule-scan overhead

### DIFF
--- a/bench/lexer.bench.ts
+++ b/bench/lexer.bench.ts
@@ -1,0 +1,32 @@
+import { bench, describe } from 'vitest'
+import { Lexer } from '../src/lexer'
+import { RISON } from '../src/rison'
+
+const BENCHMARK_OPTIONS = {
+  time: 100,
+  warmupTime: 50
+}
+
+const collectionSize = 1_000
+const largeObject = Object.fromEntries(
+  Array.from({ length: collectionSize }, (_, index) => [
+    `field${index}`,
+    index % 10 === 0
+      ? `value-${index}`
+      : index % 5 === 0
+        ? true
+        : `string-value-${index}`
+  ])
+)
+const largeObjectSource = RISON.stringify(largeObject)
+
+describe('Lexer: large object', () => {
+  bench(
+    'tokenize',
+    () => {
+      const lexer = new Lexer(largeObjectSource)
+      while (lexer.nextToken() !== null) {}
+    },
+    BENCHMARK_OPTIONS
+  )
+})

--- a/bench/rison-comparison.bench.ts
+++ b/bench/rison-comparison.bench.ts
@@ -78,6 +78,37 @@ const benchmarkFixtures = [
   return { ...fixture, source: rison2Source }
 })
 
+const parseFixtures = [
+  { name: 'bare string', source: 'foo', value: 'foo' },
+  { name: 'number', source: '123', value: 123 },
+  { name: 'quoted string', source: "'hello world'", value: 'hello world' },
+  { name: 'true', source: '!t', value: true },
+  { name: 'null', source: '!n', value: null },
+  {
+    name: 'object',
+    source: '(a:1,b:foo)',
+    value: { a: 1, b: 'foo' }
+  },
+  {
+    name: 'array',
+    source: '!(foo,123,!t)',
+    value: ['foo', 123, true]
+  }
+]
+
+for (const fixture of parseFixtures) {
+  deepStrictEqual(
+    RISON.parse(fixture.source),
+    fixture.value,
+    `rison2 should parse ${fixture.name}`
+  )
+  deepStrictEqual(
+    rison.decode(fixture.source),
+    fixture.value,
+    `rison should parse ${fixture.name}`
+  )
+}
+
 describe.each(benchmarkFixtures)('RISON stringify: $name', (fixture) => {
   bench(
     'rison2',
@@ -96,6 +127,11 @@ describe.each(benchmarkFixtures)('RISON stringify: $name', (fixture) => {
 })
 
 describe.each(benchmarkFixtures)('RISON parse: $name', (fixture) => {
+  bench('rison2', () => RISON.parse(fixture.source), BENCHMARK_OPTIONS)
+  bench('rison', () => rison.decode(fixture.source), BENCHMARK_OPTIONS)
+})
+
+describe.each(parseFixtures)('RISON parse: $name', (fixture) => {
   bench('rison2', () => RISON.parse(fixture.source), BENCHMARK_OPTIONS)
   bench('rison', () => rison.decode(fixture.source), BENCHMARK_OPTIONS)
 })

--- a/docs/rison-comparison.md
+++ b/docs/rison-comparison.md
@@ -13,31 +13,59 @@ Install dependencies and run the comparison benchmarks:
 
 ```bash
 npm install
-npm run bench -- --testNamePattern='RISON'
+npm run bench -- bench/rison-comparison.bench.ts
+```
+
+Run the lexer-only benchmark separately when attributing parser performance
+changes to tokenization:
+
+```bash
+npm run bench -- bench/lexer.bench.ts
 ```
 
 Run the benchmark several times when comparing results. CPU frequency,
 background activity, JIT compilation, and garbage collection can affect short
 microbenchmarks.
 
-## Inputs
+## Comparison Inputs
 
-The benchmark covers four JSON-compatible structures:
+The public API comparison covers four JSON-compatible structures:
 
 - A small object with primitive values.
 - A nested medium object with arrays.
 - A large array containing 1,000 objects.
 - A large object containing 1,000 properties.
 
+It also includes focused parse cases for representative Rison values:
+
+- A bare string and a quoted string.
+- A number.
+- True and null literals.
+- A small object and a small array containing mixed primitive values.
+
 Both implementations receive the same JavaScript value in each stringify
 case. Both parse implementations receive the same Rison source, generated
-once with `RISON.stringify` before measurement.
+once before measurement. The focused parse sources are declared directly so
+that each implementation parses identical input.
+
+## Lexer Attribution
+
+The lexer-only benchmark tokenizes the same 1,000-property large object used
+by the public API comparison. Its Rison source is generated with
+`RISON.stringify` before measurement. Each timed iteration creates a new
+`Lexer` and consumes all tokens.
+
+This internal benchmark helps determine whether a parser performance change
+comes from tokenization. Its throughput must not be compared directly with the
+public parse or stringify cases because it measures a different operation.
 
 ## Correctness Checks
 
 Before measurement, each implementation parses the other implementation's
 encoded output. `node:assert.deepStrictEqual` verifies that the result matches
-the original fixture. These checks run outside the timed callbacks.
+the original fixture. The focused parse cases similarly verify each parser's
+result against an explicit expected value. These checks and all source
+generation run outside the timed callbacks.
 
 Encoded strings are not required to match exactly because object key ordering
 can differ while representing the same value.
@@ -56,6 +84,8 @@ regression thresholds.
 
 - Inputs are synthetic and do not represent every real-world Rison payload.
 - O-Rison, A-Rison, URI escaping, and error paths are not measured.
+- The lexer benchmark is an internal attribution tool, not a public API
+  comparison with the `rison` package.
 - The short measurement window increases sensitivity to JIT compilation,
   inlining, garbage collection, and background activity.
 - Results from different machines or runtime versions are not directly

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -1,11 +1,105 @@
 import { Lexer } from './lexer'
-import { COMMA, NUMBER, OBJECT_ARRAY_END, OBJECT_START, STRING } from './token'
+import {
+  ARRAY_START,
+  COLON,
+  COMMA,
+  FALSE,
+  NULL,
+  NUMBER,
+  OBJECT_ARRAY_END,
+  OBJECT_START,
+  STRING,
+  TRUE,
+  type Token
+} from './token'
 
 describe('Lexer.nextToken', () => {
-  it('matches regular expressions at the current position after failures', () => {
-    const lexer = new Lexer('(42,field)')
+  it.each<[string, Token]>([
+    [
+      "'hello!! !'world'",
+      { kind: STRING, value: "'hello!! !'world'", position: 0 }
+    ],
+    ['(', { kind: OBJECT_START, value: '(', position: 0 }],
+    [')', { kind: OBJECT_ARRAY_END, value: ')', position: 0 }],
+    [':', { kind: COLON, value: ':', position: 0 }],
+    [',', { kind: COMMA, value: ',', position: 0 }],
+    ['!(', { kind: ARRAY_START, value: '!(', position: 0 }],
+    ['!n', { kind: NULL, value: '!n', position: 0 }],
+    ['!t', { kind: TRUE, value: '!t', position: 0 }],
+    ['!f', { kind: FALSE, value: '!f', position: 0 }],
+    ['-12.5e-2', { kind: NUMBER, value: '-12.5e-2', position: 0 }],
+    ['field-123', { kind: STRING, value: 'field-123', position: 0 }]
+  ])('dispatches the first character of %j', (source, token) => {
+    const lexer = new Lexer(source)
+
+    expect(lexer.nextToken()).toStrictEqual(token)
+    expect(lexer.position()).toBe(source.length)
+    expect(lexer.nextToken()).toBeNull()
+  })
+
+  it.each([
+    [
+      '123field',
+      [
+        { kind: NUMBER, value: '123', position: 0 },
+        { kind: STRING, value: 'field', position: 3 }
+      ]
+    ],
+    [
+      '!tfield',
+      [
+        { kind: TRUE, value: '!t', position: 0 },
+        { kind: STRING, value: 'field', position: 2 }
+      ]
+    ],
+    [
+      '01',
+      [
+        { kind: NUMBER, value: '0', position: 0 },
+        { kind: NUMBER, value: '1', position: 1 }
+      ]
+    ]
+  ])('preserves partial tokenization of %j', (source, tokens) => {
+    const lexer = new Lexer(source)
+
+    expect(tokens.map(() => lexer.nextToken())).toStrictEqual(tokens)
+    expect(lexer.nextToken()).toBeNull()
+  })
+
+  it.each([
+    ['!', 0, 'Unexpected token ! in Rison at position 0'],
+    ['!x', 0, 'Unexpected token ! in Rison at position 0'],
+    [' ', 0, 'Unexpected token   in Rison at position 0'],
+    ['*', 0, 'Unexpected token * in Rison at position 0'],
+    ['@', 0, 'Unexpected token @ in Rison at position 0'],
+    ['$', 0, 'Unexpected token $ in Rison at position 0'],
+    ['foo@', 1, 'Unexpected token @ in Rison at position 3'],
+    ['(-x', 1, 'Unexpected token - in Rison at position 1']
+  ])('rejects reserved or invalid characters in %j', (source, consumedTokens, message) => {
+    const lexer = new Lexer(source)
+    for (let i = 0; i < consumedTokens; i++) lexer.nextToken()
+
+    expect(() => lexer.nextToken()).toThrowError(message)
+  })
+
+  it.each([
+    "'",
+    "'escaped!'",
+    "'trailing!"
+  ])('preserves unterminated quote errors for %j', (source) => {
+    expect(() => new Lexer(source).nextToken()).toThrowError(
+      'Unexpected end of Rison input'
+    )
+  })
+
+  it('tracks positions across every fixed-token branch', () => {
+    const lexer = new Lexer('():,!(!n!t!f')
 
     expect([
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
+      lexer.nextToken(),
       lexer.nextToken(),
       lexer.nextToken(),
       lexer.nextToken(),
@@ -13,10 +107,14 @@ describe('Lexer.nextToken', () => {
       lexer.nextToken()
     ]).toStrictEqual([
       { kind: OBJECT_START, value: '(', position: 0 },
-      { kind: NUMBER, value: '42', position: 1 },
+      { kind: OBJECT_ARRAY_END, value: ')', position: 1 },
+      { kind: COLON, value: ':', position: 2 },
       { kind: COMMA, value: ',', position: 3 },
-      { kind: STRING, value: 'field', position: 4 },
-      { kind: OBJECT_ARRAY_END, value: ')', position: 9 }
+      { kind: ARRAY_START, value: '!(', position: 4 },
+      { kind: NULL, value: '!n', position: 6 },
+      { kind: TRUE, value: '!t', position: 8 },
+      { kind: FALSE, value: '!f', position: 10 },
+      null
     ])
   })
 })

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -13,70 +13,11 @@ import {
   type TokenKind
 } from './token'
 
-type Rule<T extends TokenKind> = (
-  source: string,
-  pos: number
-) => Token<T> | null
-
-const rules = {
-  quote: (): Rule<typeof STRING> => (source, pos) => {
-    if (!source.startsWith("'", pos)) return null
-
-    let i = pos
-    while (true) {
-      if (source.length <= ++i) {
-        throw new SyntaxError('Unexpected end of Rison input')
-      }
-      switch (source[i]) {
-        case '!':
-          // In a quoted string, `!` escapes the following character.
-          i++
-          continue
-        case "'":
-          return {
-            kind: STRING,
-            value: source.slice(pos, i + 1),
-            position: pos
-          }
-      }
-    }
-  },
-  string:
-    <T extends TokenKind>(kind: T): Rule<T> =>
-    (source, pos) =>
-      source.startsWith(kind, pos)
-        ? { kind, value: kind, position: pos }
-        : null,
-  regexp: <T extends TokenKind>(kind: T, reg: RegExp): Rule<T> => {
-    const sticky = new RegExp(
-      reg.source,
-      reg.sticky ? reg.flags : `${reg.flags}y`
-    )
-
-    return (source, pos) => {
-      sticky.lastIndex = pos
-      const match = sticky.exec(source)
-      return match != null ? { kind, value: match[0], position: pos } : null
-    }
-  }
-}
-
-const RULES: Array<Rule<TokenKind>> = [
-  rules.quote(),
-  rules.string(OBJECT_START),
-  rules.string(ARRAY_START),
-  rules.string(OBJECT_ARRAY_END),
-  rules.string(NULL),
-  rules.string(TRUE),
-  rules.string(FALSE),
-  rules.string(COLON),
-  rules.string(COMMA),
-  // A bare identifier cannot start with a digit or `-`; all characters exclude
-  // the ASCII space, quote, and Rison reserved punctuation.
-  rules.regexp(STRING, /[^0-9- '!:(),*@$][^ '!:(),*@$]*/),
-  // Numbers use a zero or non-zero-leading integer with optional fraction and exponent.
-  rules.regexp(NUMBER, /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/)
-]
+// A bare identifier cannot start with a digit or `-`; all characters exclude
+// the ASCII space, quote, and Rison reserved punctuation.
+const STRING_REGEXP = /[^0-9- '!:(),*@$][^ '!:(),*@$]*/y
+// Numbers use a zero or non-zero-leading integer with optional fraction and exponent.
+const NUMBER_REGEXP = /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/y
 
 /**
  * Tokenizes a Rison source string while tracking the current position.
@@ -118,19 +59,72 @@ export class Lexer {
   public nextToken(): Token<TokenKind> | null {
     if (this.#pos >= this.#source.length) return null
 
-    for (const rule of RULES) {
-      const token = rule(this.#source, this.#pos)
-      if (token !== null) {
-        this.#pos += token.value.length
-        return token
-      }
+    const current = this.#source.charAt(this.#pos)
+    switch (current) {
+      case "'":
+        return this.#readQuotedString()
+      case '(':
+        return this.#createToken(OBJECT_START)
+      case ')':
+        return this.#createToken(OBJECT_ARRAY_END)
+      case ':':
+        return this.#createToken(COLON)
+      case ',':
+        return this.#createToken(COMMA)
+      case '!':
+        switch (this.#source[this.#pos + 1]) {
+          case '(':
+            return this.#createToken(ARRAY_START)
+          case 'n':
+            return this.#createToken(NULL)
+          case 't':
+            return this.#createToken(TRUE)
+          case 'f':
+            return this.#createToken(FALSE)
+        }
     }
+
+    const numberStart = current === '-' || (current >= '0' && current <= '9')
+    const token = numberStart
+      ? this.#readRegexp(NUMBER, NUMBER_REGEXP)
+      : this.#readRegexp(STRING, STRING_REGEXP)
+    if (token !== null) return token
 
     throw new SyntaxError(
       `Unexpected token ${this.#source[this.#pos]} in Rison at position ${
         this.#pos
       }`
     )
+  }
+
+  #readRegexp<T extends TokenKind>(kind: T, regexp: RegExp): Token<T> | null {
+    regexp.lastIndex = this.#pos
+    const match = regexp.exec(this.#source)
+    return match === null ? null : this.#createToken(kind, match[0])
+  }
+
+  #createToken<T extends TokenKind>(kind: T, value: string = kind): Token<T> {
+    const token = { kind, value, position: this.#pos }
+    this.#pos += value.length
+    return token
+  }
+
+  #readQuotedString(): Token<typeof STRING> {
+    const start = this.#pos
+    let end = start
+    while (true) {
+      if (this.#source.length <= ++end) {
+        throw new SyntaxError('Unexpected end of Rison input')
+      }
+      switch (this.#source[end]) {
+        case '!':
+          // In a quoted string, `!` escapes the following character.
+          end++
+          continue
+        case "'":
+          return this.#createToken(STRING, this.#source.slice(start, end + 1))
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Dispatch lexer tokens from the current character instead of trying every rule in sequence. Preserve token values, positions, partial tokenization, and syntax error behavior.

Add focused primitive parse and lexer-only benchmarks, plus documentation for reproducing and interpreting the measurements.

Refs: #87