### PR TITLE
perf: reduce RISON parse allocations

### DIFF
--- a/bench/string-parsing.bench.ts
+++ b/bench/string-parsing.bench.ts
@@ -1,0 +1,53 @@
+import { deepStrictEqual } from 'node:assert'
+import { bench, describe } from 'vitest'
+import { Lexer } from '../src/lexer'
+import { RISON } from '../src/rison'
+
+const BENCHMARK_OPTIONS = {
+  time: 100,
+  warmupTime: 50
+}
+
+const fixtures = [
+  {
+    name: 'bare string',
+    source: 'hello-world',
+    value: 'hello-world'
+  },
+  {
+    name: 'quoted string without escapes',
+    source: "'hello world'",
+    value: 'hello world'
+  },
+  {
+    name: 'escaped quoted string',
+    source: "'hello!! !'world'",
+    value: "hello! 'world"
+  }
+]
+
+for (const fixture of fixtures) {
+  deepStrictEqual(
+    RISON.parse(fixture.source),
+    fixture.value,
+    `RISON should parse ${fixture.name}`
+  )
+}
+
+describe.each(fixtures)('String parsing: $name', (fixture) => {
+  bench(
+    'lexer-only',
+    () => {
+      const lexer = new Lexer(fixture.source)
+      while (lexer.nextToken() !== null) {}
+    },
+    BENCHMARK_OPTIONS
+  )
+  bench(
+    'RISON.parse',
+    () => {
+      RISON.parse(fixture.source)
+    },
+    BENCHMARK_OPTIONS
+  )
+})

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -132,6 +132,35 @@ describe('Lexer.nextToken', () => {
   })
 })
 
+describe('Lexer.nextTokenKind', () => {
+  it('updates current token state without changing nextToken output', () => {
+    const lexer = new Lexer("!('hello world',!t)")
+
+    expect(lexer.nextTokenKind()).toBe(ARRAY_START)
+    expect(lexer.currentTokenKind()).toBe(ARRAY_START)
+    expect(lexer.currentTokenValue()).toBe('!(')
+    expect(lexer.currentTokenPosition()).toBe(0)
+    expect(lexer.nextTokenKind()).toBe(STRING)
+    expect(lexer.currentTokenValue()).toBe("'hello world'")
+    expect(lexer.currentTokenPosition()).toBe(2)
+    expect(lexer.currentQuotedStringHasEscape()).toBe(false)
+    expect(lexer.nextToken()).toStrictEqual({
+      kind: COMMA,
+      value: ',',
+      position: 15
+    })
+  })
+
+  it('retains raw and decoded values for escaped quoted strings', () => {
+    const lexer = new Lexer("'hello!! !'world'")
+
+    expect(lexer.nextTokenKind()).toBe(STRING)
+    expect(lexer.currentTokenValue()).toBe("'hello!! !'world'")
+    expect(lexer.currentQuotedStringHasEscape()).toBe(true)
+    expect(lexer.currentDecodedQuotedString()).toBe("hello! 'world")
+  })
+})
+
 describe('Lexer.syntaxError', () => {
   it.each([
     ["('hello'", "Unexpected token ' in Rison at position 1"],

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -93,18 +93,6 @@ describe('Lexer.nextToken', () => {
     )
   })
 
-  it.each([
-    ["'hello world'", false],
-    ["'hello!! !'world'", true],
-    ['hello', false]
-  ])('records whether %j contains quoted escapes', (source, expected) => {
-    const lexer = new Lexer(source)
-    const token = lexer.nextToken()
-
-    if (token === null) throw new Error('Expected a token')
-    expect(lexer.quotedStringHasEscape(token)).toBe(expected)
-  })
-
   it('tracks positions across every fixed-token branch', () => {
     const lexer = new Lexer('():,!(!n!t!f')
 
@@ -137,7 +125,6 @@ describe('Lexer.nextTokenKind', () => {
     const lexer = new Lexer("!('hello world',!t)")
 
     expect(lexer.nextTokenKind()).toBe(ARRAY_START)
-    expect(lexer.currentTokenKind()).toBe(ARRAY_START)
     expect(lexer.currentTokenValue()).toBe('!(')
     expect(lexer.currentTokenPosition()).toBe(0)
     expect(lexer.nextTokenKind()).toBe(STRING)

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -85,11 +85,24 @@ describe('Lexer.nextToken', () => {
   it.each([
     "'",
     "'escaped!'",
-    "'trailing!"
+    "'trailing!",
+    "'こんにちは!"
   ])('preserves unterminated quote errors for %j', (source) => {
     expect(() => new Lexer(source).nextToken()).toThrowError(
       'Unexpected end of Rison input'
     )
+  })
+
+  it.each([
+    ["'hello world'", false],
+    ["'hello!! !'world'", true],
+    ['hello', false]
+  ])('records whether %j contains quoted escapes', (source, expected) => {
+    const lexer = new Lexer(source)
+    const token = lexer.nextToken()
+
+    if (token === null) throw new Error('Expected a token')
+    expect(lexer.quotedStringHasEscape(token)).toBe(expected)
   })
 
   it('tracks positions across every fixed-token branch', () => {

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -24,6 +24,8 @@ const NUMBER_REGEXP = /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/y
  */
 export class Lexer {
   #pos = 0
+  #quotedStringHasEscape = false
+  #quotedStringToken: Token<typeof STRING> | null = null
   #source: string
 
   /**
@@ -47,6 +49,17 @@ export class Lexer {
    */
   public length(): number {
     return this.#source.length
+  }
+
+  /**
+   * Reports whether a quoted string token contained an escape marker.
+   *
+   * @param token - A token returned by this lexer.
+   * @returns Whether the token is the most recently read quoted string and
+   * contains an escape marker.
+   */
+  public quotedStringHasEscape(token: Token): boolean {
+    return token === this.#quotedStringToken && this.#quotedStringHasEscape
   }
 
   /**
@@ -112,6 +125,7 @@ export class Lexer {
   #readQuotedString(): Token<typeof STRING> {
     const start = this.#pos
     let end = start
+    let hasEscape = false
     while (true) {
       if (this.#source.length <= ++end) {
         throw new SyntaxError('Unexpected end of Rison input')
@@ -119,10 +133,18 @@ export class Lexer {
       switch (this.#source[end]) {
         case '!':
           // In a quoted string, `!` escapes the following character.
+          hasEscape = true
           end++
           continue
-        case "'":
-          return this.#createToken(STRING, this.#source.slice(start, end + 1))
+        case "'": {
+          const token = this.#createToken(
+            STRING,
+            this.#source.slice(start, end + 1)
+          )
+          this.#quotedStringToken = token
+          this.#quotedStringHasEscape = hasEscape
+          return token
+        }
       }
     }
   }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -23,13 +23,11 @@ const NUMBER_REGEXP = /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/y
  * Tokenizes a Rison source string while tracking the current position.
  */
 export class Lexer {
-  #currentTokenKind: TokenKind | null = null
   #currentTokenPosition = 0
   #currentTokenValue = ''
   #decodedQuotedString = ''
   #pos = 0
   #quotedStringHasEscape = false
-  #quotedStringToken: Token | null = null
   #source: string
 
   /**
@@ -53,13 +51,6 @@ export class Lexer {
    */
   public length(): number {
     return this.#source.length
-  }
-
-  /**
-   * @returns The kind of the most recently read token.
-   */
-  public currentTokenKind(): TokenKind | null {
-    return this.#currentTokenKind
   }
 
   /**
@@ -92,17 +83,6 @@ export class Lexer {
   }
 
   /**
-   * Reports whether a quoted string token contained an escape marker.
-   *
-   * @param token - A token returned by this lexer.
-   * @returns Whether the token is the most recently read quoted string and
-   * contains an escape marker.
-   */
-  public quotedStringHasEscape(token: Token): boolean {
-    return token === this.#quotedStringToken && this.#quotedStringHasEscape
-  }
-
-  /**
    * Reads the next token and advances the current position.
    *
    * @returns The next token, or `null` when the source has been consumed.
@@ -113,14 +93,11 @@ export class Lexer {
     const kind = this.nextTokenKind()
     if (kind === null) return null
 
-    const token = {
+    return {
       kind,
       value: this.#currentTokenValue,
       position: this.#currentTokenPosition
     }
-    this.#quotedStringToken =
-      kind === STRING && token.value[0] === "'" ? token : null
-    return token
   }
 
   /**
@@ -178,7 +155,6 @@ export class Lexer {
   }
 
   #createToken<T extends TokenKind>(kind: T, value: string = kind): T {
-    this.#currentTokenKind = kind
     this.#currentTokenPosition = this.#pos
     this.#currentTokenValue = value
     this.#quotedStringHasEscape = false

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -23,9 +23,13 @@ const NUMBER_REGEXP = /-?([1-9][0-9]*|[0-9])(\.[0-9]+)?(e-?[0-9]+)?/y
  * Tokenizes a Rison source string while tracking the current position.
  */
 export class Lexer {
+  #currentTokenKind: TokenKind | null = null
+  #currentTokenPosition = 0
+  #currentTokenValue = ''
+  #decodedQuotedString = ''
   #pos = 0
   #quotedStringHasEscape = false
-  #quotedStringToken: Token<typeof STRING> | null = null
+  #quotedStringToken: Token | null = null
   #source: string
 
   /**
@@ -52,6 +56,42 @@ export class Lexer {
   }
 
   /**
+   * @returns The kind of the most recently read token.
+   */
+  public currentTokenKind(): TokenKind | null {
+    return this.#currentTokenKind
+  }
+
+  /**
+   * @returns The value of the most recently read token.
+   */
+  public currentTokenValue(): string {
+    return this.#currentTokenValue
+  }
+
+  /**
+   * @returns The position of the most recently read token.
+   */
+  public currentTokenPosition(): number {
+    return this.#currentTokenPosition
+  }
+
+  /**
+   * @returns Whether the most recently read token was a quoted string with an
+   * escape marker.
+   */
+  public currentQuotedStringHasEscape(): boolean {
+    return this.#quotedStringHasEscape
+  }
+
+  /**
+   * @returns The decoded value of the most recently read quoted string.
+   */
+  public currentDecodedQuotedString(): string {
+    return this.#decodedQuotedString
+  }
+
+  /**
    * Reports whether a quoted string token contained an escape marker.
    *
    * @param token - A token returned by this lexer.
@@ -70,6 +110,27 @@ export class Lexer {
    * unterminated quoted string.
    */
   public nextToken(): Token<TokenKind> | null {
+    const kind = this.nextTokenKind()
+    if (kind === null) return null
+
+    const token = {
+      kind,
+      value: this.#currentTokenValue,
+      position: this.#currentTokenPosition
+    }
+    this.#quotedStringToken =
+      kind === STRING && token.value[0] === "'" ? token : null
+    return token
+  }
+
+  /**
+   * Reads the next token without allocating a token object.
+   *
+   * @returns The next token kind, or `null` when the source has been consumed.
+   * @throws {SyntaxError} If the source contains an invalid token or an
+   * unterminated quoted string.
+   */
+  public nextTokenKind(): TokenKind | null {
     if (this.#pos >= this.#source.length) return null
 
     const current = this.#source.charAt(this.#pos)
@@ -98,10 +159,10 @@ export class Lexer {
     }
 
     const numberStart = current === '-' || (current >= '0' && current <= '9')
-    const token = numberStart
+    const kind = numberStart
       ? this.#readRegexp(NUMBER, NUMBER_REGEXP)
       : this.#readRegexp(STRING, STRING_REGEXP)
-    if (token !== null) return token
+    if (kind !== null) return kind
 
     throw new SyntaxError(
       `Unexpected token ${this.#source[this.#pos]} in Rison at position ${
@@ -110,22 +171,27 @@ export class Lexer {
     )
   }
 
-  #readRegexp<T extends TokenKind>(kind: T, regexp: RegExp): Token<T> | null {
+  #readRegexp<T extends TokenKind>(kind: T, regexp: RegExp): T | null {
     regexp.lastIndex = this.#pos
     const match = regexp.exec(this.#source)
     return match === null ? null : this.#createToken(kind, match[0])
   }
 
-  #createToken<T extends TokenKind>(kind: T, value: string = kind): Token<T> {
-    const token = { kind, value, position: this.#pos }
+  #createToken<T extends TokenKind>(kind: T, value: string = kind): T {
+    this.#currentTokenKind = kind
+    this.#currentTokenPosition = this.#pos
+    this.#currentTokenValue = value
+    this.#quotedStringHasEscape = false
     this.#pos += value.length
-    return token
+    return kind
   }
 
-  #readQuotedString(): Token<typeof STRING> {
+  #readQuotedString(): typeof STRING {
     const start = this.#pos
     let end = start
     let hasEscape = false
+    let segmentStart = start + 1
+    this.#decodedQuotedString = ''
     while (true) {
       if (this.#source.length <= ++end) {
         throw new SyntaxError('Unexpected end of Rison input')
@@ -134,15 +200,20 @@ export class Lexer {
         case '!':
           // In a quoted string, `!` escapes the following character.
           hasEscape = true
+          this.#decodedQuotedString += this.#source.slice(segmentStart, end)
           end++
+          this.#decodedQuotedString += this.#source[end]
+          segmentStart = end + 1
           continue
         case "'": {
           const token = this.#createToken(
             STRING,
             this.#source.slice(start, end + 1)
           )
-          this.#quotedStringToken = token
           this.#quotedStringHasEscape = hasEscape
+          if (hasEscape) {
+            this.#decodedQuotedString += this.#source.slice(segmentStart, end)
+          }
           return token
         }
       }
@@ -156,10 +227,21 @@ export class Lexer {
    * @returns A syntax error containing the token and its source position.
    */
   public syntaxError(token: Token): SyntaxError {
+    return this.#syntaxError(token.position)
+  }
+
+  /**
+   * Creates an error for the most recently consumed token.
+   *
+   * @returns A syntax error containing the token and its source position.
+   */
+  public currentTokenSyntaxError(): SyntaxError {
+    return this.#syntaxError(this.#currentTokenPosition)
+  }
+
+  #syntaxError(position: number): SyntaxError {
     return new SyntaxError(
-      `Unexpected token ${this.#source[token.position]} in Rison at position ${
-        token.position
-      }`
+      `Unexpected token ${this.#source[position]} in Rison at position ${position}`
     )
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,7 +10,6 @@ import {
   OBJECT_START,
   STRING,
   TRUE,
-  type Token,
   type TokenKind
 } from './token'
 
@@ -39,13 +38,14 @@ export class Parser {
   public readAsAny(): unknown {
     const val = this.asAny(this.nextToken())
     if (this.#lexer.position() < this.#lexer.length()) {
-      throw this.#lexer.syntaxError(this.nextToken())
+      this.nextToken()
+      throw this.#lexer.currentTokenSyntaxError()
     }
     return val
   }
 
-  private asAny(token: Token): unknown {
-    switch (token.kind) {
+  private asAny(kind: TokenKind): unknown {
+    switch (kind) {
       case NULL:
         return null
       case TRUE:
@@ -53,74 +53,66 @@ export class Parser {
       case FALSE:
         return false
       case STRING:
-        return this.asString(token)
+        return this.asString()
       case NUMBER:
-        return Number(token.value)
+        return Number(this.#lexer.currentTokenValue())
       case OBJECT_START:
         return this.readAsObject()
       case ARRAY_START:
         return this.readAsArray()
       default:
-        throw this.#lexer.syntaxError(token)
+        throw this.#lexer.currentTokenSyntaxError()
     }
   }
 
-  private asString(token: Token): string {
-    if (token.value[0] !== "'") return token.value
-    if (!this.#lexer.quotedStringHasEscape(token)) {
-      return token.value.slice(1, -1)
+  private asString(): string {
+    const value = this.#lexer.currentTokenValue()
+    if (value[0] !== "'") return value
+    if (!this.#lexer.currentQuotedStringHasEscape()) {
+      return value.slice(1, -1)
     }
-
-    const end = token.value.length - 1
-    let decoded = ''
-    let segmentStart = 1
-    for (let index = 1; index < end; index++) {
-      if (token.value[index] !== '!') continue
-      decoded += token.value.slice(segmentStart, index)
-      decoded += token.value[++index]
-      segmentStart = index + 1
-    }
-    return decoded + token.value.slice(segmentStart, end)
+    return this.#lexer.currentDecodedQuotedString()
   }
 
   private readAsObject(): Record<string, unknown> {
     const obj: Record<string, unknown> = {}
-    let token = this.nextToken()
-    while (token.kind !== OBJECT_ARRAY_END) {
-      const key = this.asString(token)
+    let kind = this.nextToken()
+    while (kind !== OBJECT_ARRAY_END) {
+      const key = this.asString()
       this.expectToken(COLON)
       const val = this.asAny(this.nextToken())
       obj[key] = val
 
-      token = this.nextToken()
-      if (token.kind === OBJECT_ARRAY_END) break
-      if (token.kind !== COMMA) throw this.#lexer.syntaxError(token)
-      token = this.nextToken()
+      kind = this.nextToken()
+      if (kind === OBJECT_ARRAY_END) break
+      if (kind !== COMMA) throw this.#lexer.currentTokenSyntaxError()
+      kind = this.nextToken()
     }
     return obj
   }
 
   private readAsArray(): unknown[] {
     const arr: unknown[] = []
-    let token = this.nextToken()
-    while (token.kind !== OBJECT_ARRAY_END) {
-      arr.push(this.asAny(token))
-      token = this.nextToken()
-      if (token.kind === OBJECT_ARRAY_END) break
-      if (token.kind !== COMMA) throw this.#lexer.syntaxError(token)
-      token = this.nextToken()
+    let kind = this.nextToken()
+    while (kind !== OBJECT_ARRAY_END) {
+      arr.push(this.asAny(kind))
+      kind = this.nextToken()
+      if (kind === OBJECT_ARRAY_END) break
+      if (kind !== COMMA) throw this.#lexer.currentTokenSyntaxError()
+      kind = this.nextToken()
     }
     return arr
   }
 
   private expectToken<T extends TokenKind>(kind: T): void {
-    const token = this.nextToken()
-    if (token.kind !== kind) throw this.#lexer.syntaxError(token)
+    if (this.nextToken() !== kind) {
+      throw this.#lexer.currentTokenSyntaxError()
+    }
   }
 
-  private nextToken(): Token {
-    const token = this.#lexer.nextToken()
-    if (token == null) throw new SyntaxError('Unexpected end of Rison input')
-    return token
+  private nextToken(): TokenKind {
+    const kind = this.#lexer.nextTokenKind()
+    if (kind === null) throw new SyntaxError('Unexpected end of Rison input')
+    return kind
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -66,10 +66,21 @@ export class Parser {
   }
 
   private asString(token: Token): string {
-    // Remove Rison's escape marker: `!!` represents `!`, and `!'` represents `'`.
-    return token.value[0] === "'"
-      ? token.value.replace(/!./g, (c) => c[1] as string).slice(1, -1)
-      : token.value
+    if (token.value[0] !== "'") return token.value
+    if (!this.#lexer.quotedStringHasEscape(token)) {
+      return token.value.slice(1, -1)
+    }
+
+    const end = token.value.length - 1
+    let decoded = ''
+    let segmentStart = 1
+    for (let index = 1; index < end; index++) {
+      if (token.value[index] !== '!') continue
+      decoded += token.value.slice(segmentStart, index)
+      decoded += token.value[++index]
+      segmentStart = index + 1
+    }
+    return decoded + token.value.slice(segmentStart, end)
   }
 
   private readAsObject(): Record<string, unknown> {

--- a/src/rison.test.ts
+++ b/src/rison.test.ts
@@ -96,6 +96,14 @@ describe('RISON.parse', () => {
       expect(error).toHaveProperty('message', message)
     }
   })
+
+  it.each([
+    ["'hello world'", 'hello world'],
+    ["'!! !' !! !''", "! ' ! '"],
+    ["'こんにちは!!世界!'終わり'", "こんにちは!世界'終わり"]
+  ])('decodes quoted string %j as %j', (input, expected) => {
+    expect(RISON.parse(input)).toBe(expected)
+  })
 })
 
 describe('RISON.stringify', () => {


### PR DESCRIPTION
Reduce parser allocations and repeated quoted-string scanning while preserving the public API, token output, parsed values, syntax errors, and source positions.

## Changes

- add focused lexer-only and full-parse string benchmarks
- let Parser consume token kinds and lexer state without allocating Token objects
- fast-path unescaped quoted strings with one inner slice
- decode escaped quoted strings during the lexer scan without regexp replacement
- preserve Lexer.nextToken() output for existing callers

## Benchmarks

Environment: Node.js v24.16.0, Darwin 25.4.0 arm64, macOS 26.4.1. Each comparison used three runs with Vitest benchmark time 100 ms and warmup 50 ms.

- quoted string full parse median: 5.61M -> 8.27M ops/s (+47%)
- bare string full parse median: 7.89M -> 7.54M ops/s (-4%, not material at this duration)
- large-array full parse median: 677 -> 645 ops/s (-5%, not material at this duration)
- large-object and escaped-string runs showed substantial outliers; observed RME reached 39% and 99%, so no strong collection conclusion is drawn
- public lexer large-object median after the change: 6.83k ops/s, versus the measured baseline of about 6.45k ops/s

The focused results demonstrate that quoted-string rescanning was a material bottleneck. Token objects are now removed from the Parser hot path. A direct cursor parser would require a broader refactor, and these measurements do not yet justify that additional complexity; it should be evaluated separately if further profiling identifies parser/lexer calls as the dominant remaining cost.

## Verification

- npm run lint
- npm test -- --run (172 tests)
- npm run build
- git diff --check

Refs: #89